### PR TITLE
Removing api key and other minor tweaks

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 mass_mandrill
 =============
 
-mass_mandrill is thin wrapper around mandrill-api gem that makes sending emails with Mandrill easier and more pleasent to use. Goal is to reasemble Rails' ActiveMailer API.
+mass_mandrill is thin wrapper around mandrill-api gem that makes sending emails with Mandrill easier and more pleasent to use. Goal is to resemble Rails' ActionMailer API.
 
 mass_mandrill supports bulk email sending and Mandrill templates. To learn more about these topics, visit [Mandrill Support](http://help.mandrill.com/home).
 
@@ -54,15 +54,18 @@ mail(to: addresses,
 Install
 -------
 
-Add mass_mandrill to your Gemfile and bundle. And create Rails initializer with
-your Mandrill API key:
+Add mass_mandrill to your Gemfile:
 
-```ruby
-# config/initializers/mass_mandrill.rb
-MassMandrill.config do |config|
-  config.api_key = 'YOUR_API_KEY'
-end
-```
+    gem 'mass_mandrill'
+
+Install it:
+
+    bundle
+
+Or if you are not using bundler:
+
+    gem install mass_mandrill
+
 
 Contributing to mandrill_template
 ---------------------------------

--- a/README.markdown
+++ b/README.markdown
@@ -51,6 +51,20 @@ mail(to: addresses,
      merge_vars: merge_vars)
 ```
 
+You can omit some options like `from` and `subject` in which case the default `from` and `subject` that are stored remotely on the Mandrill server will be used.
+You can also send additional configuration to the message (like `inline_css`, `track_opens`, `track_clicks`, `preserve_recipients`, ...) by passing a hash of `message_extra`.
+For a complete list of these parameters, check the [Mandrill Message API](https://mandrillapp.com/api/docs/messages.JSON.html).
+
+```ruby
+mail(to: addresses,
+     global_merge_vars: global_merge_vars,
+     merge_vars: merge_vars,
+     message_extra: {
+       inline_css: true,
+       track_opens: false
+     })
+```
+
 Install
 -------
 
@@ -66,9 +80,18 @@ Or if you are not using bundler:
 
     gem install mass_mandrill
 
+Place your Mandrill API key in your environment. If your application runs on [heroku](http://www.heroku.com), this is automatically done.
+If you are using [foreman](https://github.com/ddollar/foreman) to run your application, place it in your `.env`:
 
-Contributing to mandrill_template
----------------------------------
+    MANDRILL_APIKEY=PASTE_YOUR_API_KEY_HERE
+
+Otherwise, edit your `config/environment.rb` to include the key:
+
+    #config/environment.rb
+    ENV['MANDRILL_APIKEY'] = 'PASTE_YOUR_API_KEY_HERE'
+
+Contributing to mass_mandrill
+-----------------------------
  
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it.

--- a/lib/mass_mandrill/config.rb
+++ b/lib/mass_mandrill/config.rb
@@ -3,6 +3,7 @@ require 'singleton'
 module MassMandrill
   class Config
     include Singleton
-    attr_accessor :api_key
+    #api_key is now read automatically from ENV in the official mandrill-api gem
+    #attr_accessor :api_key
   end
 end

--- a/lib/mass_mandrill/mandrill_mail.rb
+++ b/lib/mass_mandrill/mandrill_mail.rb
@@ -9,7 +9,7 @@ module MassMandrill
       @template_content = template_content
       @message = message
 
-      @mandrill = ::Mandrill::API.new(MassMandrill.config.api_key)
+      @mandrill = ::Mandrill::API.new
     end
 
     def deliver

--- a/lib/mass_mandrill/mandrill_mailer.rb
+++ b/lib/mass_mandrill/mandrill_mailer.rb
@@ -29,7 +29,7 @@ module MassMandrill
         :preserve_recipients => options[:preserve_recipients],
         :global_merge_vars => options[:global_merge_vars],
         :merge_vars => options[:merge_vars]
-      }
+      }.merge(options[:message_extra] || {})
     end
 
     def to(addresses)

--- a/lib/mass_mandrill/mandrill_mailer.rb
+++ b/lib/mass_mandrill/mandrill_mailer.rb
@@ -6,8 +6,8 @@ module MassMandrill
       @template_name = template_name
     end
 
-    def self.method_missing(method_name, *args)
-      new(method_name).send(method_name, *args)
+    def self.method_missing(method_name, *args, &block)
+      new(method_name).send(method_name, *args, &block)
     end
 
     def mail(options)

--- a/lib/mass_mandrill/mandrill_mailer.rb
+++ b/lib/mass_mandrill/mandrill_mailer.rb
@@ -42,17 +42,17 @@ module MassMandrill
 
     def from_email(from)
       scan = scan_email(from)
-      scan.empty? ? from : scan.first[1..-2]
+      scan.blank? ? from : scan.first[1..-2]
     end
 
     def from_name(from)
-      unless scan_email(from).empty?
+      unless scan_email(from).blank?
         from.split(/\</).first.strip
       end
     end
 
     def scan_email(from)
-      from.scan(/\<.*\>/)
+      from.try(:scan, /\<.*\>/)
     end
   end
 end


### PR DESCRIPTION
Hi there, I have simplified the integration of the gem by removing the api_key configuration (now read from ENV by the official mandril-api gem). Also did some minor tweaks, please read commit messages.
